### PR TITLE
Add repo-local config and --branch flag for configurable base branch

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -127,7 +127,7 @@ func configUsage() {
 	fmt.Println("review config <subcommand>")
 	fmt.Println()
 	fmt.Println("Subcommands:")
-	fmt.Println("  show                      show current configuration")
+	fmt.Println("  show                      display current configuration")
 	fmt.Println("  set <key> <value>         set a repo-local config value")
 	fmt.Println()
 	fmt.Println("Keys:")

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,137 @@
+package cmd
+
+import (
+	"fmt"
+
+	"review/internal/config"
+	"review/internal/git"
+	"review/internal/repoconfig"
+)
+
+func configCmd(args []string, g globals, cfg config.Config) error {
+	if len(args) == 0 || isHelpArg(args[0]) {
+		configUsage()
+
+		return nil
+	}
+
+	switch args[0] {
+	case "show":
+		return configShowCmd(g, cfg)
+	case "set":
+		return configSetCmd(args[1:], g)
+	default:
+		return fmt.Errorf("unknown config subcommand %q", args[0])
+	}
+}
+
+func configSetCmd(args []string, g globals) error {
+	if len(args) < 2 || isHelpArg(args[0]) {
+		fmt.Println("review config set <key> <value>")
+		fmt.Println("keys: defaultBranch")
+
+		return nil
+	}
+
+	key, val := args[0], args[1]
+
+	repo, err := git.Open(g.repo)
+	if err != nil {
+		return err
+	}
+
+	repoCfg, err := repoconfig.Load(repo)
+	if err != nil {
+		return err
+	}
+
+	switch key {
+	case "defaultBranch":
+		repoCfg.DefaultBranch = val
+	default:
+		return fmt.Errorf("unknown config key %q", key)
+	}
+
+	if err := repoconfig.Save(repo, repoCfg); err != nil {
+		return err
+	}
+
+	path, _ := repoconfig.Path(repo)
+
+	if g.json {
+		printJSON(map[string]any{"key": key, "value": val, "path": path})
+	} else {
+		fmt.Printf("Set %s = %s in %s\n", key, val, path)
+	}
+
+	return nil
+}
+
+func configShowCmd(g globals, cfg config.Config) error {
+	repo, err := git.Open(g.repo)
+	if err != nil {
+		return err
+	}
+
+	repoCfg, err := repoconfig.Load(repo)
+	if err != nil {
+		return err
+	}
+
+	path, _ := repoconfig.Path(repo)
+
+	// Effective value: repo config overrides user config.
+	effectiveBranch := cfg.DefaultBaseBranch
+	if repoCfg.DefaultBranch != "" {
+		effectiveBranch = repoCfg.DefaultBranch
+	}
+
+	if g.json {
+		printJSON(map[string]any{
+			"repo_config": map[string]any{
+				"path":          path,
+				"defaultBranch": repoCfg.DefaultBranch,
+			},
+			"user_config": map[string]any{
+				"defaultBaseBranch": cfg.DefaultBaseBranch,
+			},
+			"effective": map[string]any{
+				"defaultBranch": effectiveBranch,
+			},
+		})
+
+		return nil
+	}
+
+	fmt.Printf("Repo config (%s):\n", path)
+	fmt.Printf("  defaultBranch: %s\n", orUnset(repoCfg.DefaultBranch))
+	fmt.Println()
+	fmt.Printf("User config:\n")
+	fmt.Printf("  defaultBaseBranch: %s\n", cfg.DefaultBaseBranch)
+	fmt.Println()
+	fmt.Printf("Effective:\n")
+	fmt.Printf("  defaultBranch: %s\n", effectiveBranch)
+
+	return nil
+}
+
+func orUnset(s string) string {
+	if s == "" {
+		return "(not set)"
+	}
+
+	return s
+}
+
+func configUsage() {
+	fmt.Println("review config <subcommand>")
+	fmt.Println()
+	fmt.Println("Subcommands:")
+	fmt.Println("  show                      show current configuration")
+	fmt.Println("  set <key> <value>         set a repo-local config value")
+	fmt.Println()
+	fmt.Println("Keys:")
+	fmt.Println("  defaultBranch             base branch for diffs (e.g. main, develop)")
+	fmt.Println()
+	fmt.Println("Config is stored in .git/review/config.yaml")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"review/internal/config"
 	"review/internal/daemon"
 	"review/internal/git"
+	"review/internal/repoconfig"
 )
 
 type globals struct {
@@ -85,6 +86,8 @@ func run(args []string, g globals, cfg config.Config) error {
 		return requestChangesCmd(args[1:], g)
 	case "watch":
 		return watchCmd(args[1:], g)
+	case "config":
+		return configCmd(args[1:], g, cfg)
 	case "lsp":
 		return lspCmd(args[1:], cfg)
 	case "tui":
@@ -137,14 +140,19 @@ func daemonCmd(args []string, g globals, cfg config.Config) error {
 }
 
 func openCmd(args []string, g globals, cfg config.Config) error {
-	base := cfg.DefaultBaseBranch
+	base := ""
+	baseFlagSet := false
 	pos := []string{}
 
 	for i := 0; i < len(args); i++ {
-		if args[i] == "--base" && i+1 < len(args) {
-			base = args[i+1]
-			i++
-		} else {
+		switch args[i] {
+		case "--base", "--branch":
+			if i+1 < len(args) {
+				base = args[i+1]
+				baseFlagSet = true
+				i++
+			}
+		default:
 			pos = append(pos, args[i])
 		}
 	}
@@ -160,6 +168,10 @@ func openCmd(args []string, g globals, cfg config.Config) error {
 	repo, err := git.Open(g.repo)
 	if err != nil {
 		return err
+	}
+
+	if !baseFlagSet {
+		base = resolveBaseBranch(repo, cfg)
 	}
 
 	c := client.New(g.port)
@@ -358,6 +370,7 @@ func rootCommands() []commandHelp {
 		{name: "approve", summary: "push and mark the review approved"},
 		{name: "request-changes", summary: "mark the review as changes requested"},
 		{name: "watch", summary: "stream review daemon events"},
+		{name: "config", summary: "show or set repo-local review configuration"},
 		{name: "lsp", summary: "list, discover, or install language servers"},
 		{name: "tui", summary: "open the keyboard-first review interface"},
 		{name: "widget", summary: "render or interact with TUI widget demos"},
@@ -367,4 +380,15 @@ func rootCommands() []commandHelp {
 func describeUsage() {
 	fmt.Println("review describe [--print] [--prompt <text>] [--provider <provider>]")
 	fmt.Println("providers: auto, anthropic, claude-cli, codex-cli, fallback")
+}
+
+// resolveBaseBranch returns the effective base branch for the given repo,
+// checking the repo-local config before falling back to the user config default.
+func resolveBaseBranch(repo git.Repo, cfg config.Config) string {
+	repoCfg, err := repoconfig.Load(repo)
+	if err == nil && repoCfg.DefaultBranch != "" {
+		return repoCfg.DefaultBranch
+	}
+
+	return cfg.DefaultBaseBranch
 }

--- a/cmd/tui.go
+++ b/cmd/tui.go
@@ -12,16 +12,18 @@ import (
 )
 
 func tuiCmd(args []string, g globals, cfg config.Config) error {
-	base := cfg.DefaultBaseBranch
+	base := ""
+	baseFlagSet := false
 	pos := []string{}
 
 	for i := 0; i < len(args); i++ {
 		switch args[i] {
-		case "--base":
+		case "--base", "--branch":
 			if i+1 >= len(args) {
-				return errors.New("--base requires a branch")
+				return errors.New(args[i] + " requires a branch name")
 			}
 			base = args[i+1]
+			baseFlagSet = true
 			i++
 		default:
 			if isHelpArg(args[i]) {
@@ -41,6 +43,11 @@ func tuiCmd(args []string, g globals, cfg config.Config) error {
 	if err != nil {
 		return err
 	}
+
+	if !baseFlagSet {
+		base = resolveBaseBranch(repo, cfg)
+	}
+
 	if err := ensureDaemon(g.port); err != nil {
 		return err
 	}
@@ -76,6 +83,12 @@ func currentSessionOrOpen(repo git.Repo, c client.Client, base string) (models.S
 }
 
 func tuiUsage() {
-	fmt.Println("review tui [repo] [--base <branch>]")
+	fmt.Println("review tui [repo] [--branch <branch>]")
 	fmt.Println("opens or creates the current branch review session in a keyboard-first TUI")
+	fmt.Println()
+	fmt.Println("Flags:")
+	fmt.Println("  --branch <branch>   base branch to diff against (overrides repo and user config)")
+	fmt.Println("  --base <branch>     alias for --branch")
+	fmt.Println()
+	fmt.Println("Branch resolution order: --branch flag > .git/review/config.yaml > user config > main")
 }

--- a/internal/repoconfig/config.go
+++ b/internal/repoconfig/config.go
@@ -62,7 +62,7 @@ func Save(repo git.Repo, cfg Config) error {
 func parse(content string) Config {
 	cfg := Config{}
 
-	for _, line := range strings.Split(content, "\n") {
+	for line := range strings.SplitSeq(content, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
@@ -73,8 +73,7 @@ func parse(content string) Config {
 			continue
 		}
 
-		switch strings.TrimSpace(key) {
-		case "defaultBranch":
+		if strings.TrimSpace(key) == "defaultBranch" {
 			cfg.DefaultBranch = strings.TrimSpace(val)
 		}
 	}

--- a/internal/repoconfig/config.go
+++ b/internal/repoconfig/config.go
@@ -1,0 +1,93 @@
+package repoconfig
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"review/internal/git"
+)
+
+// Config holds repo-local review configuration stored in .git/review/config.yaml.
+type Config struct {
+	DefaultBranch string
+}
+
+// Path returns the path to the repo-local config file.
+func Path(repo git.Repo) (string, error) {
+	gitDir, err := repo.GitDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(gitDir, "review", "config.yaml"), nil
+}
+
+// Load reads .git/review/config.yaml for the given repo.
+// Returns an empty Config (no error) if the file doesn't exist yet.
+func Load(repo git.Repo) (Config, error) {
+	path, err := Path(repo)
+	if err != nil {
+		return Config{}, err
+	}
+
+	//nolint:gosec // Path is derived from git dir, not user input.
+	b, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return Config{}, nil
+	}
+
+	if err != nil {
+		return Config{}, err
+	}
+
+	return parse(string(b)), nil
+}
+
+// Save writes cfg to .git/review/config.yaml, creating the directory if needed.
+func Save(repo git.Repo, cfg Config) error {
+	path, err := Path(repo)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, []byte(marshal(cfg)), 0o600)
+}
+
+func parse(content string) Config {
+	cfg := Config{}
+
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		key, val, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+
+		switch strings.TrimSpace(key) {
+		case "defaultBranch":
+			cfg.DefaultBranch = strings.TrimSpace(val)
+		}
+	}
+
+	return cfg
+}
+
+func marshal(cfg Config) string {
+	var sb strings.Builder
+
+	if cfg.DefaultBranch != "" {
+		fmt.Fprintf(&sb, "defaultBranch: %s\n", cfg.DefaultBranch)
+	}
+
+	return sb.String()
+}


### PR DESCRIPTION
Adds .git/review/config.yaml as a repo-local config file that lets each
repository declare its default base branch (e.g. develop, master) instead of
always falling back to the global user config default of "main".

- internal/repoconfig: new package reads/writes .git/review/config.yaml
  with a minimal YAML parser (no extra dependency)
- review config show: displays repo config, user config, and effective values
- review config set defaultBranch <branch>: writes the repo-local config
- openCmd and tuiCmd now resolve the base branch via:
  1. --branch / --base CLI flag (highest priority)
  2. .git/review/config.yaml defaultBranch
  3. user config DefaultBaseBranch
  4. hardcoded "main" fallback

https://claude.ai/code/session_01EbzJQEqJx6V9aLveh3DqPj