### PR TITLE
Support workspace mode: auto-discover nested git repos in TUI

### DIFF
--- a/cmd/tui.go
+++ b/cmd/tui.go
@@ -39,9 +39,27 @@ func tuiCmd(args []string, g globals, cfg config.Config) error {
 		g.repo = pos[0]
 	}
 
-	repo, err := git.Open(g.repo)
-	if err != nil {
-		return err
+	// Try to open as a single git repo first.
+	repo, repoErr := git.Open(g.repo)
+	if repoErr != nil {
+		// Not a git repo — check if the path contains nested repos (workspace mode).
+		nested, err := git.DiscoverNested(g.repo)
+		if err != nil || len(nested) == 0 {
+			return repoErr
+		}
+		if !baseFlagSet {
+			base = cfg.DefaultBaseBranch
+		}
+		if err := ensureDaemon(g.port); err != nil {
+			return err
+		}
+		c := client.New(g.port)
+		return tui.RunWorkspace(tui.WorkspaceOptions{
+			Repos:  nested,
+			Client: c,
+			Config: cfg,
+			Base:   base,
+		})
 	}
 
 	if !baseFlagSet {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -515,6 +515,33 @@ func parseUnifiedDiff(raw string, uncommitted bool) map[string]models.DiffFile {
 	return result
 }
 
+// DiscoverNested finds git repositories in immediate subdirectories of dir.
+// Hidden directories (names starting with ".") are skipped.
+func DiscoverNested(dir string) ([]Repo, error) {
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	entries, err := os.ReadDir(abs)
+	if err != nil {
+		return nil, err
+	}
+
+	var repos []Repo
+	for _, entry := range entries {
+		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+		subPath := filepath.Join(abs, entry.Name())
+		if _, statErr := os.Stat(filepath.Join(subPath, ".git")); statErr == nil {
+			repos = append(repos, Repo{Path: subPath})
+		}
+	}
+
+	return repos, nil
+}
+
 func parseRemote(remote string) (string, string, string) {
 	remote = strings.TrimSuffix(remote, ".git")
 	if after, ok := strings.CutPrefix(remote, "git@"); ok {

--- a/internal/tui/widgets/model.go
+++ b/internal/tui/widgets/model.go
@@ -30,6 +30,8 @@ func NewModelWithMode(name string, props Props, interactive bool) Model {
 	switch name {
 	case "workspace":
 		widget = NewWorkspace(props)
+	case "workspace-list":
+		widget = NewWorkspaceList(props)
 	case "file-list":
 		widget = NewFileList(props)
 	case "diff":
@@ -107,6 +109,11 @@ func RenderTree(name string) string {
 			"  FileListWidget [tea.Model]",
 			"  DiffWidget [tea.Model + bubbles/viewport]",
 			"  ContextMenuWidget [tea.Model]",
+		},
+		"workspace-list": {
+			"WorkspaceListWidget [tea.Model]",
+			"  Header [lipgloss.Style]",
+			"  RepoRow * n [lipgloss.Style]",
 		},
 		"file-list":    {"FileListWidget [tea.Model]", "  FileRow * n [lipgloss.Style]"},
 		"diff":         {"DiffWidget [tea.Model]", "  viewport.Model", "  DiffLine * n [lipgloss.Style]"},

--- a/internal/tui/widgets/props.go
+++ b/internal/tui/widgets/props.go
@@ -16,7 +16,7 @@ type Props struct {
 }
 
 func Names() []string {
-	return []string{"workspace", "file-list", "diff", "context-menu", "goto-file", "search", "comments"}
+	return []string{"workspace", "workspace-list", "file-list", "diff", "context-menu", "goto-file", "search", "comments"}
 }
 
 func DefaultProps() Props {

--- a/internal/tui/widgets/review.go
+++ b/internal/tui/widgets/review.go
@@ -376,6 +376,63 @@ func renderCommentRows(data WorkspaceData) []string {
 	return rows
 }
 
+// WorkspaceRepoItem holds display data for one repo in the workspace list.
+type WorkspaceRepoItem struct {
+	Name        string
+	Branch      string
+	Status      string
+	FileCount   int
+	CommitCount int
+	Loading     bool
+	Err         error
+}
+
+// RenderWorkspaceList renders the multi-repo workspace selection screen.
+func RenderWorkspaceList(width, height int, repos []WorkspaceRepoItem, selected int, status string) string {
+	if width <= 0 {
+		width = 96
+	}
+	if height <= 0 {
+		height = 28
+	}
+
+	header := titleStyle.Render("Workspace") + mutedStyle.Render("  "+status)
+	headerBox := fixedBox(width, 1, []string{header})
+
+	bodyHeight := max(height-5, 4)
+	rows := []string{titleStyle.Render("Repositories")}
+	for i, repo := range repos {
+		prefix := "  "
+		if i == selected {
+			prefix = "> "
+		}
+		var detail string
+		switch {
+		case repo.Loading:
+			detail = mutedStyle.Render("loading...")
+		case repo.Err != nil:
+			detail = mutedStyle.Render("error: " + repo.Err.Error())
+		default:
+			st := ""
+			if repo.Status != "" {
+				st = repo.Status + "  "
+			}
+			detail = mutedStyle.Render(fmt.Sprintf("%s%s  %d files  %d commits", st, repo.Branch, repo.FileCount, repo.CommitCount))
+		}
+		nameWidth := 24
+		row := fmt.Sprintf("%s%-*s  %s", prefix, nameWidth, truncateMiddle(repo.Name, nameWidth), detail)
+		if i == selected {
+			row = activeStyle.Render(row)
+		}
+		rows = append(rows, row)
+	}
+
+	body := fixedBox(width, bodyHeight, rows)
+	help := mutedStyle.Render("j/k navigate   Enter open review   R reload   q quit")
+
+	return lipgloss.JoinVertical(lipgloss.Left, headerBox, body, help) + "\n"
+}
+
 func RenderFilePicker(width int, query string, files []FileItem, cursor int) string {
 	rows := []string{titleStyle.Render("Go to file"), "/" + query}
 	matches := FilterFileItems(query, files)

--- a/internal/tui/widgets/workspace_list.go
+++ b/internal/tui/widgets/workspace_list.go
@@ -1,0 +1,44 @@
+package widgets
+
+import tea "github.com/charmbracelet/bubbletea"
+
+// WorkspaceList is the demo widget for the workspace repo selection screen.
+type WorkspaceList struct {
+	props Props
+}
+
+func NewWorkspaceList(props Props) WorkspaceList {
+	return WorkspaceList{props: props}
+}
+
+func (w WorkspaceList) Init() tea.Cmd { return nil }
+
+func (w WorkspaceList) Update(tea.Msg) (tea.Model, tea.Cmd) { return w, nil }
+
+func (w WorkspaceList) View() string {
+	return RenderWorkspaceList(w.props.Width, w.props.Height, sampleWorkspaceRepos, 0, "3 repos")
+}
+
+var sampleWorkspaceRepos = []WorkspaceRepoItem{
+	{
+		Name:        "api-gateway",
+		Branch:      "feature/auth-refresh",
+		Status:      "in_review",
+		FileCount:   7,
+		CommitCount: 3,
+	},
+	{
+		Name:        "web-client",
+		Branch:      "feature/auth-refresh",
+		Status:      "in_review",
+		FileCount:   12,
+		CommitCount: 5,
+	},
+	{
+		Name:        "infra",
+		Branch:      "main",
+		Status:      "",
+		FileCount:   0,
+		CommitCount: 0,
+	},
+}

--- a/internal/tui/workspace.go
+++ b/internal/tui/workspace.go
@@ -1,0 +1,294 @@
+package tui
+
+import (
+	"fmt"
+	"path/filepath"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"review/internal/client"
+	"review/internal/config"
+	"review/internal/git"
+	"review/internal/models"
+	"review/internal/repoconfig"
+	"review/internal/tui/widgets"
+)
+
+// WorkspaceOptions configures a multi-repo workspace TUI session.
+type WorkspaceOptions struct {
+	Repos  []git.Repo
+	Client client.Client
+	Config config.Config
+	Base   string
+}
+
+type workspaceRepoState struct {
+	repo    git.Repo
+	name    string
+	branch  string
+	session models.Session
+	files   []models.DiffFile
+	commits int
+	err     error
+	loading bool
+}
+
+type wsMode int
+
+const (
+	wsModeList   wsMode = iota
+	wsModeReview
+)
+
+type workspaceModel struct {
+	opts     WorkspaceOptions
+	width    int
+	height   int
+	repos    []workspaceRepoState
+	selected int
+	mode     wsMode
+	status   string
+	review   *model
+	program  *tea.Program
+}
+
+type workspaceRepoLoadedMsg struct {
+	index   int
+	branch  string
+	session models.Session
+	files   []models.DiffFile
+	commits int
+	err     error
+}
+
+// RunWorkspace launches the multi-repo workspace TUI.
+func RunWorkspace(opts WorkspaceOptions) error {
+	m := newWorkspaceModel(opts)
+	p := tea.NewProgram(m, tea.WithAltScreen())
+	m.program = p
+	_, err := p.Run()
+	return err
+}
+
+func newWorkspaceModel(opts WorkspaceOptions) *workspaceModel {
+	repos := make([]workspaceRepoState, len(opts.Repos))
+	for i, repo := range opts.Repos {
+		repos[i] = workspaceRepoState{
+			repo:    repo,
+			name:    filepath.Base(repo.Path),
+			loading: true,
+		}
+	}
+	return &workspaceModel{
+		opts:   opts,
+		repos:  repos,
+		mode:   wsModeList,
+		status: "loading...",
+	}
+}
+
+func (m *workspaceModel) Init() tea.Cmd {
+	cmds := make([]tea.Cmd, len(m.repos))
+	for i := range m.repos {
+		cmds[i] = m.loadRepoCmd(i)
+	}
+	return tea.Batch(cmds...)
+}
+
+func (m *workspaceModel) loadRepoCmd(index int) tea.Cmd {
+	repo := m.repos[index].repo
+	base := m.baseForRepo(repo)
+	c := m.opts.Client
+	return func() tea.Msg {
+		branch, err := repo.Branch()
+		if err != nil {
+			return workspaceRepoLoadedMsg{index: index, err: err}
+		}
+		session, err := workspaceOpenSession(repo, c, branch, base)
+		if err != nil {
+			return workspaceRepoLoadedMsg{index: index, branch: branch, err: err}
+		}
+		files, _, err := c.Diff(repo.Path, session, "", "", true)
+		if err != nil {
+			return workspaceRepoLoadedMsg{index: index, branch: branch, session: session, err: err}
+		}
+		commits, _ := c.Commits(repo.Path, session)
+		return workspaceRepoLoadedMsg{
+			index:   index,
+			branch:  branch,
+			session: session,
+			files:   files,
+			commits: len(commits),
+		}
+	}
+}
+
+func (m *workspaceModel) baseForRepo(repo git.Repo) string {
+	repoCfg, err := repoconfig.Load(repo)
+	if err == nil && repoCfg.DefaultBranch != "" {
+		return repoCfg.DefaultBranch
+	}
+	return m.opts.Base
+}
+
+func workspaceOpenSession(repo git.Repo, c client.Client, branch, base string) (models.Session, error) {
+	sessions, err := c.Sessions(repo.Path)
+	if err != nil {
+		return models.Session{}, err
+	}
+	for i := len(sessions) - 1; i >= 0; i-- {
+		s := sessions[i]
+		if s.Repo == repo.Path && s.Branch == branch && s.Status != models.StatusApproved {
+			return s, nil
+		}
+	}
+	return c.Open(repo.Path, base)
+}
+
+func (m *workspaceModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		if m.mode == wsModeReview && m.review != nil {
+			next, cmd := m.review.Update(msg)
+			if nm, ok := next.(*model); ok {
+				m.review = nm
+			}
+			return m, cmd
+		}
+		return m, nil
+
+	case workspaceRepoLoadedMsg:
+		if msg.index >= 0 && msg.index < len(m.repos) {
+			r := &m.repos[msg.index]
+			r.loading = false
+			r.branch = msg.branch
+			r.session = msg.session
+			r.files = msg.files
+			r.commits = msg.commits
+			r.err = msg.err
+		}
+		loading := 0
+		for _, r := range m.repos {
+			if r.loading {
+				loading++
+			}
+		}
+		if loading > 0 {
+			m.status = fmt.Sprintf("loading (%d remaining)...", loading)
+		} else {
+			m.status = fmt.Sprintf("%d repos", len(m.repos))
+		}
+		return m, nil
+
+	case tea.KeyMsg:
+		if m.mode == wsModeReview && m.review != nil {
+			if msg.String() == "esc" {
+				return m.exitReview()
+			}
+			next, cmd := m.review.Update(msg)
+			if nm, ok := next.(*model); ok {
+				m.review = nm
+			}
+			return m, cmd
+		}
+		return m.handleListKey(msg)
+
+	default:
+		// Route all other messages (loadedMsg, watcherEventMsg, etc.) to the active review model.
+		if m.mode == wsModeReview && m.review != nil {
+			next, cmd := m.review.Update(msg)
+			if nm, ok := next.(*model); ok {
+				m.review = nm
+			}
+			return m, cmd
+		}
+	}
+
+	return m, nil
+}
+
+func (m *workspaceModel) handleListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "q", "ctrl+c":
+		return m, tea.Quit
+	case "j", "down":
+		if m.selected < len(m.repos)-1 {
+			m.selected++
+		}
+	case "k", "up":
+		if m.selected > 0 {
+			m.selected--
+		}
+	case "enter", " ":
+		return m.enterReview()
+	case "R":
+		m.status = "reloading..."
+		for i := range m.repos {
+			m.repos[i].loading = true
+		}
+		cmds := make([]tea.Cmd, len(m.repos))
+		for i := range m.repos {
+			cmds[i] = m.loadRepoCmd(i)
+		}
+		return m, tea.Batch(cmds...)
+	}
+	return m, nil
+}
+
+func (m *workspaceModel) enterReview() (tea.Model, tea.Cmd) {
+	if m.selected >= len(m.repos) {
+		return m, nil
+	}
+	r := m.repos[m.selected]
+	if r.loading || r.err != nil {
+		return m, nil
+	}
+	reviewOpts := Options{
+		RepoPath: r.repo.Path,
+		Session:  r.session,
+		Client:   m.opts.Client,
+		Config:   m.opts.Config,
+	}
+	review := newModel(reviewOpts)
+	review.program = m.program
+	review.width = m.width
+	review.height = m.height
+	m.review = review
+	m.mode = wsModeReview
+	return m, review.Init()
+}
+
+func (m *workspaceModel) exitReview() (tea.Model, tea.Cmd) {
+	if m.review != nil {
+		m.review.stopWatcher()
+		m.review = nil
+	}
+	m.mode = wsModeList
+	m.repos[m.selected].loading = true
+	return m, m.loadRepoCmd(m.selected)
+}
+
+func (m *workspaceModel) View() string {
+	if m.mode == wsModeReview && m.review != nil {
+		return m.review.View()
+	}
+	return m.renderList()
+}
+
+func (m *workspaceModel) renderList() string {
+	items := make([]widgets.WorkspaceRepoItem, len(m.repos))
+	for i, r := range m.repos {
+		items[i] = widgets.WorkspaceRepoItem{
+			Name:        r.name,
+			Branch:      r.branch,
+			Status:      r.session.Status,
+			FileCount:   len(r.files),
+			CommitCount: r.commits,
+			Loading:     r.loading,
+			Err:         r.err,
+		}
+	}
+	return widgets.RenderWorkspaceList(m.width, m.height, items, m.selected, m.status)
+}


### PR DESCRIPTION
When `review tui <path>` is given a directory that isn't itself a git
repo but contains git repos one level deep, the TUI now enters workspace
mode. It lists all discovered repos with their branch, file count, and
commit count; j/k navigate the list, Enter opens the full review for
the selected repo, Esc returns to the list, and R reloads all repos.

Closes #27

https://claude.ai/code/session_01MrBWmfcPx23cZKxD8Za6P4